### PR TITLE
Environment variable DEFAULT_UID introduced

### DIFF
--- a/oauth2-provider/README.md
+++ b/oauth2-provider/README.md
@@ -19,6 +19,7 @@ With Docker
 * `CLIENTS`: Comma-separated list of accepted client IDs and secrets, e.g. `"client1=secret1,client2=secret2"`.
 * `USERS`: Needed for the `password` grant. Same format as `CLIENTS`.
 * `DEFAULT_REALM`: Default realm to use if none was specified (default is "employees").
+* `DEFAULT_UID`: Default uid to use if none was specified (default is "testUser").
 
 ## API
 

--- a/oauth2-provider/src/server.js
+++ b/oauth2-provider/src/server.js
@@ -52,6 +52,7 @@ if (!process.env.USERS) {
 }
 
 DEFAULT_REALM = process.env.DEFAULT_REALM || 'employees';
+DEFAULT_UID = process.env.DEFAULT_UID || 'testUser';
 
 function generateToken(uid, realm, scope) {
     var token = uuid.v4();
@@ -59,7 +60,7 @@ function generateToken(uid, realm, scope) {
         access_token: token,
         expiration_date: Date.now() + 3600 * 1000,
         token_type: 'Bearer',
-        uid: uid,
+        uid: uid || DEFAULT_UID,
         realm: realm || DEFAULT_REALM,
         scope: scope || []
     };


### PR DESCRIPTION
As the AbstractAuthenticationExtractor is looking for a valid uid and the mock doesn't provide it in the moment (as stated in the server.js line 246), I recommend to use an environment variable to inject a uid.

Otherwise I always get an exception in the frontend that the uid in accessToken should never be empty.