### PR TITLE
Accept authorization headers as first choice

### DIFF
--- a/oauth2-provider/src/server.js
+++ b/oauth2-provider/src/server.js
@@ -175,7 +175,7 @@ server.post('/access_token', checkClientCredentials, function(req, res) {
  */
 
 server.get('/tokeninfo', function(req,res) {
-    var requestedToken = req.query.access_token;
+    var requestedToken = (req.headers.authorization) ? req.headers.authorization.split(' ')[1] : req.query.access_token;
     if (!requestedToken) {
         return res
                 .status(400)


### PR DESCRIPTION
To use the mock with the newest spring-oauth2-server library, the tokeninfo endpoint has to accept tokens set in an authorization header.