### PR TITLE
Return payload in case of invalid client or user credentials

### DIFF
--- a/oauth2-provider/src/server.js
+++ b/oauth2-provider/src/server.js
@@ -123,7 +123,10 @@ function checkClientCredentials(req, res, next) {
         })) {
             next();
         } else {
-            return res.status(401).send();
+            return res.status(401).send({
+                error: 'invalid_client',
+                error_description: 'Client authentication failed'
+            });
         }
     } else {
         next();
@@ -165,7 +168,10 @@ server.post('/access_token', checkClientCredentials, function(req, res) {
                 token_type: 'Bearer'
             });
         } else {
-            res.status(401).send();
+            res.status(401).send({
+                error: 'invalid_grant',
+                error_description: 'The provided access grant is invalid, expired, or revoked.'
+            });
         }
     }
 });


### PR DESCRIPTION
This mimics what our current production endpoint returns in case of wrong client or user credentials. While testing invalid credentials in one of our applications, I noticed that with the mock I get a NullPointerException as I expect a body to be returned in case of an HTTP status code 401.